### PR TITLE
Changing k=1 for 1 expert per layer

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -1535,6 +1535,10 @@ class MistralAdapter(BaseModelAdapter):
         model, tokenizer = super().load_model(model_path, from_pretrained_kwargs)
         model.config.eos_token_id = tokenizer.eos_token_id
         model.config.pad_token_id = tokenizer.pad_token_id
+
+        # Set num_experts_per_tok to 1 by default
+        model.config.num_experts_per_tok = 1
+
         return model, tokenizer
 
     def get_default_conv_template(self, model_path: str) -> Conversation:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

Changing to one expert per token for mixtral model during inference by changing model config properly before it is initialized.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).